### PR TITLE
Modified dockerfile to work with the new sdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.11-slim-bookworm
 RUN apt update \
     && apt upgrade -y \
     && apt install -y --no-install-recommends \
     gettext \
-    libmpv1 \
+    libmpv-dev \
     p7zip \
     pulseaudio \
     && apt autoclean \


### PR DESCRIPTION
Changed to use `python:3-slim-bookworm` as the base image and change to install `libmpv-dev` for the SDK to work correctly.