### PR TITLE
Fixes Dockerfile to support new TeamTalk5 SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.11-slim-bookworm
 RUN apt update \
     && apt upgrade -y \
     && apt install -y --no-install-recommends \
     gettext \
-    libmpv1 \
+    libmpv2 \
     p7zip \
     pulseaudio \
     && apt autoclean \


### PR DESCRIPTION
Base image was changed to slim-bookworm because the new TeamTalk5 SDK is known to not work on Debian 11 bullseye.
Also libmpv1 dependency was replaced with libmpv2 because the former is not available in bookworm anymore.
