### PR TITLE
Adds sudo command which allows any user to become admin via entering a specific password

### DIFF
--- a/bot/commands/__init__.py
+++ b/bot/commands/__init__.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import logging
 import re
 from threading import Thread
-from typing import Any, List, TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Any, List, Tuple
 
 from bot import app_vars, errors
-from bot.TeamTalk.structs import Message, User, UserType
 from bot.commands import admin_commands, user_commands
 from bot.commands.task_processor import TaskProcessor
+from bot.TeamTalk.structs import Message, User, UserType
 
 re_command = re.compile("[a-z]+")
 re_arg_split = re.compile(r"(?<!\\)\|")
@@ -51,6 +51,7 @@ class CommandProcessor:
             "gl": user_commands.GetLinkCommand,
             "dl": user_commands.DownloadCommand,
             "r": user_commands.RecentsCommand,
+            "sudo": user_commands.SudoCommand,
         }
         self.admin_commands_dict = {
             "cg": admin_commands.ChangeGenderCommand,
@@ -113,6 +114,8 @@ class CommandProcessor:
             )
 
     def check_access(self, user: User, command: str) -> bool:
+        if command == "sudo":
+            return True
         if (
             not user.is_admin and user.type != UserType.Admin
         ) or app_vars.app_name in user.client_name:

--- a/bot/commands/user_commands.py
+++ b/bot/commands/user_commands.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
-from typing import List, Optional, TYPE_CHECKING
 
+from typing import TYPE_CHECKING, List, Optional
+
+from bot import app_vars, errors
 from bot.commands.command import Command
 from bot.player.enums import Mode, State, TrackType
 from bot.TeamTalk.structs import User, UserRight
-from bot import errors, app_vars
 
 if TYPE_CHECKING:
     from bot.TeamTalk.structs import User
@@ -540,3 +541,20 @@ class DownloadCommand(Command):
                 return self.translator.translate("Live streams cannot be downloaded")
         else:
             return self.translator.translate("Nothing is playing")
+
+
+class SudoCommand(Command):
+    def help(self) -> str:
+        return self.translator.translate(
+            "Accepts admin password and allows an usual user to become a temporary administrator of the bot until logout"
+        )
+
+    def __call__(self, arg: str, user: User) -> Optional[str]:
+        if user.is_admin:
+            return self.translator.translate("You are already an administrator")
+        if self._bot.ttclient.try_add_temporary_admin(arg, user):
+            return self.translator.translate(
+                "You are temporary admin until you log out"
+            )
+        else:
+            return self.translator.translate("Wrong password or other error")

--- a/bot/config/models.py
+++ b/bot/config/models.py
@@ -27,6 +27,7 @@ class PlayerModel(BaseModel):
 
 
 class TeamTalkUserModel(BaseModel):
+    temporary_admin_password: str = ""
     admins: List[str] = ["admin"]
     banned_users: List[str] = []
 

--- a/config_default.json
+++ b/config_default.json
@@ -36,6 +36,7 @@
         "reconnection_attempts": -1,
         "reconnection_timeout": 10,
         "users": {
+            "temporary_admin_password": "",
             "admins": [
                 "admin"
             ],


### PR DESCRIPTION
`sudo` command works even if the bot is locked.
The syntax is `sudo <password>` where `<password>` is a password which is set in `config.json` in teamtalk > users section.
If the password is not set or empty, this command will always fail. This is for security.