### PR TITLE
feat: add cookie file support for youtube

### DIFF
--- a/bot/config/models.py
+++ b/bot/config/models.py
@@ -12,7 +12,6 @@ class GeneralModel(BaseModel):
     time_format: str = r"%H:%M"
     start_commands: List[str] = []
 
-
 class SoundDevicesModel(BaseModel):
     output_device: int = 0
     input_device: int = 0
@@ -25,7 +24,6 @@ class PlayerModel(BaseModel):
     volume_fading_interval: float = 0.025
     seek_step: int = 5
     player_options: Dict[str, Any] = {}
-
 
 class TeamTalkUserModel(BaseModel):
     admins: List[str] = ["admin"]
@@ -64,6 +62,9 @@ class VkModel(BaseModel):
 
 class YtModel(BaseModel):
     enabled: bool = True
+class YtModel(BaseModel):
+    enabled: bool = True
+    cookiefile_path: str = ""
 
 
 class YamModel(BaseModel):

--- a/bot/services/yt.py
+++ b/bot/services/yt.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import logging
+import os
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -37,6 +38,9 @@ class YtService(_Service):
             "logger": logging.getLogger("root"),
         }
 
+        if self.config.cookiefile_path and os.path.isfile(self.config.cookiefile_path):
+            self._ydl_config |= {"cookiefile": self.config.cookiefile_path}
+            
     def download(self, track: Track, file_path: str) -> None:
         info = track.extra_info
         if not info:

--- a/config_default.json
+++ b/config_default.json
@@ -1,4 +1,5 @@
 {
+    "config_version": 0,
     "general": {
         "language": "en",
         "send_channel_messages": true,
@@ -58,7 +59,8 @@
             "token": ""
         },
         "yt": {
-            "enabled": true
+            "enabled": true,
+            "cookiefile_path": ""
         }
     },
     "logger": {


### PR DESCRIPTION
Adds the ability to specify a cookie file path via configuration.
Passing cookies has become necessary for extracting stream
information from YouTube using yt-dlp. Without cookies, requests fail with 'Sign in to confirm you're not a bot' errors,
even for public videos, preventing playback.