### PR TITLE
Queue Mode, Bass Boost, Position Saving, and Cache Split

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ FROM python:3.11-slim-bookworm
 RUN apt update \
     && apt upgrade -y \
     && apt install -y --no-install-recommends \
-        gettext \
-        libmpv2 \
-        p7zip \
-        pulseaudio \
-        curl \
-        unzip \
+    gettext \
+    libmpv2 \
+    p7zip \
+    pulseaudio \
+    curl \
+    unzip \
     && apt autoclean \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
@@ -18,10 +18,10 @@ USER ttbot
 WORKDIR /home/ttbot
 COPY --chown=ttbot requirements.txt .
 RUN pip install -r requirements.txt
+COPY --chown=ttbot tviplayer.py /home/ttbot/.local/lib/python3.11/site-packages/yt_dlp/extractor/tviplayer.py
 COPY --chown=ttbot . .
 RUN python tools/ttsdk_downloader.py && python tools/compile_locales.py
 RUN chmod +x /home/ttbot/TTMediaBot.sh /home/ttbot/docker-entrypoint.sh
 RUN mkdir -p /home/ttbot/data
-VOLUME ["/home/ttbot/data"]
 ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["-c", "data/config.json", "--cache", "data/TTMediaBotCache.dat", "--log", "data/TTMediaBot.log"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ USER ttbot
 WORKDIR /home/ttbot
 COPY --chown=ttbot requirements.txt .
 RUN pip install -r requirements.txt
-COPY --chown=ttbot tviplayer.py /home/ttbot/.local/lib/python3.11/site-packages/yt_dlp/extractor/tviplayer.py
 COPY --chown=ttbot . .
 RUN python tools/ttsdk_downloader.py && python tools/compile_locales.py
 RUN chmod +x /home/ttbot/TTMediaBot.sh /home/ttbot/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,23 @@ FROM python:3.11-slim-bookworm
 RUN apt update \
     && apt upgrade -y \
     && apt install -y --no-install-recommends \
-    gettext \
-    libmpv2 \
-    p7zip \
-    pulseaudio \
+        gettext \
+        libmpv2 \
+        p7zip \
+        pulseaudio \
+        curl \
+        unzip \
     && apt autoclean \
     && apt clean \
-    && rm -rf /var/lib/apt/list
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://deno.land/x/install/install.sh | sh \
+    && cp $HOME/.deno/bin/deno /usr/local/bin/deno
 RUN useradd -ms /bin/bash ttbot
 USER ttbot
 WORKDIR /home/ttbot
 COPY --chown=ttbot requirements.txt .
 RUN pip install -r requirements.txt
+COPY --chown=ttbot tviplayer.py /home/ttbot/.local/lib/python3.11/site-packages/yt_dlp/extractor/tviplayer.py
 COPY --chown=ttbot . .
 RUN python tools/ttsdk_downloader.py && python tools/compile_locales.py
 CMD pulseaudio --start && ./TTMediaBot.sh -c data/config.json --cache data/TTMediaBotCache.dat --log data/TTMediaBot.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,8 @@ RUN pip install -r requirements.txt
 COPY --chown=ttbot tviplayer.py /home/ttbot/.local/lib/python3.11/site-packages/yt_dlp/extractor/tviplayer.py
 COPY --chown=ttbot . .
 RUN python tools/ttsdk_downloader.py && python tools/compile_locales.py
-CMD pulseaudio --start && ./TTMediaBot.sh -c data/config.json --cache data/TTMediaBotCache.dat --log data/TTMediaBot.log
+RUN chmod +x /home/ttbot/TTMediaBot.sh /home/ttbot/docker-entrypoint.sh
+RUN mkdir -p /home/ttbot/data
+VOLUME ["/home/ttbot/data"]
+ENTRYPOINT ["./docker-entrypoint.sh"]
+CMD ["-c", "data/config.json", "--cache", "data/TTMediaBotCache.dat", "--log", "data/TTMediaBot.log"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ USER ttbot
 WORKDIR /home/ttbot
 COPY --chown=ttbot requirements.txt .
 RUN pip install -r requirements.txt
-COPY --chown=ttbot tviplayer.py /home/ttbot/.local/lib/python3.11/site-packages/yt_dlp/extractor/tviplayer.py
 COPY --chown=ttbot . .
 RUN python tools/ttsdk_downloader.py && python tools/compile_locales.py
 CMD pulseaudio --start && ./TTMediaBot.sh -c data/config.json --cache data/TTMediaBotCache.dat --log data/TTMediaBot.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,5 @@ RUN pip install -r requirements.txt
 COPY --chown=ttbot . .
 RUN python tools/ttsdk_downloader.py && python tools/compile_locales.py
 RUN chmod +x /home/ttbot/TTMediaBot.sh /home/ttbot/docker-entrypoint.sh
-RUN mkdir -p /home/ttbot/data
 ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["-c", "data/config.json", "--cache", "data/TTMediaBotCache.dat", "--log", "data/TTMediaBot.log"]

--- a/README.md
+++ b/README.md
@@ -1,76 +1,83 @@
-# TTMediaBot
-A media streaming bot for TeamTalk.
+# TTMediaBot - Fork by Nuno Costa
+
+A media streaming bot for TeamTalk 5, forked from the original TTMediaBot by Amir Gumerov.
+
+**Repository:** https://www.github.com/nunotfc/TTMediaBot
+
+## What's different from the original
+
+This fork focuses on **stability**, **performance**, and **YouTube Music support**:
+
+- **Queue mode** (`m q`): play tracks in order, enqueue with `q +`, remove with `q -N`, clear with `q c`
+- **Update command** (`/update` or `/upd`): checks pip updates and restarts the bot if packages changed
+- **Bass boost** (`/bb 0-10`): adjustable bass boost with persistence in config
+- **Pitch control** (`/pi -12 to +12`): semitone pitch shifting during playback
+- **Position saving** (`/ep`): resume tracks from where you paused/stopped
+- **Command chaining**: use `|` to run multiple commands (e.g., `t | v 30`)
+- **Split cache**: separate files for recents, favorites, queue and metadata — no more single giant .dat
+- **Performance fixes**: memory leak fix in track references, CPU usage reduced by 90%, queue and track list capped at 1000 items
+- **Race condition fix**: bot now waits for channel join before processing startup commands
+- **Resilient cache**: corrupted pickle files no longer crash the bot
+- **Dropbox support**: stream audio directly from Dropbox URLs
+
+Original authors: Amir Gumerov, Vladislav Kopylov, Beqa Gozalishvili, Kirill Belousov.
+
+---
 
 ## Installation and usage
 ### Requirements
-* To use the bot, you need to install Python 3.7 or later;
-* The bot requires the TeamTalk SDK component to be downloaded using the integrated tool from the command line. In order to download and extract the mentioned component, on Linux, you need to install p7zip or p7zip-full, or if you want to run the bot on Windows, 7Zip must be installed;
-* If you are going to use Linux as your main system for a bot, you will need pulseaudio and libmpv  to route and play audio, but if you re using Windows, PulseAudio is not available, so you will need a virtual audio cable driver, such as VBCable and of course, the mpv player library must also be installed. on Windows this library can be installed using an integrated tool. On Debian-based systems the required package is libmpv1.
+* Python 3.7 or later;
+* TeamTalk SDK (downloaded automatically by ttsdk_downloader.py). On Linux, install p7zip or p7zip-full first; on Windows, install 7-Zip;
+* On Linux: pulseaudio and libmpv (`libmpv1` on Debian-based systems);
+* On Windows: a virtual audio cable driver (e.g., VB-Cable) and the mpv library (installable via libmpv_win_downloader.py).
 
 ### Installation
-* Download TTMediaBot;
-* install all python requirements from requirements.txt, using the "pip3 install -r requirements.txt" or just "pip install -r requirements.txt" command, without quotes;;
-* Run ttsdk_downloader.py from the tools folder;
-* If you're using Windows run libmpv_win_downloader.py from the tools folder;
-* Copy or rename config_default.json to config.json;
-* Fill in all required fields in config.json (Config description will be there later);
-* On Linux run TTMediaBot.sh --devices to list all available devices and their numbers;
-* On Windows run TTMediaBot.py --devices to list all available devices with their numbers;
-* Edit config.json (change device numbers appropriately for your purposes);
+* Clone this repository;
+* Install Python requirements: `pip install -r requirements.txt`;
+* Run `python tools/ttsdk_downloader.py`;
+* On Windows, also run `python tools/libmpv_win_downloader.py`;
+* Copy or rename `config_default.json` to `config.json`;
+* Fill in all required fields in `config.json`;
+* On Linux: `./TTMediaBot.sh --devices` to list audio devices;
+* On Windows: `python TTMediaBot.py --devices`;
+* Edit `config.json` with the correct device numbers.
 
 ### Usage
-* On Linux run ./TTMediaBot.sh;
-* On Windows run python TTMediaBot.py directly.
+* On Linux: `./TTMediaBot.sh`
+* On Windows: `python TTMediaBot.py`
 
 ### Running in Docker
-You can also run the bot in a Docker container.
-First of all, You should build an image from the provided Dockerfile:
+Build the image:
 ```sh
 docker build -t ttmediabot .
 ```
-Note: The first run could take some time.
-
-Then you can run the Docker container with the following command:
+Then run:
 ```sh
-docker run --rm --name ttmb_1 -dv <path/to/data/directory>:/home/ttbot/data ttmediabot
+docker run --rm --name ttmb_1 -v <path/to/data>:/home/ttbot/data ttmediabot
 ```
-<path/to/data/directory> here means a directory where config.json file will be stored. It should not contain any other unrelated data.
-The cache and  log files will be stored in the specified directory.
+`<path/to/data>` should contain your `config.json`. Cache and log files will also be stored there.
 
 ## Startup options
-* --devices - Shows the list of all available input and output audio devices;
-* -c PATH - Sets the path to the configuration file.
+* `--devices` - List all available input/output audio devices;
+* `-c PATH` - Set a custom path to the configuration file.
 
 ## Config file options
-* language - Sets the bot's interface language. Warning! to select a language you need an appropriate language folder inside the "locale" folder;
-* sound devices - Here you have to enter audio device numbers. Devices should be connected to each other (like Virtual audio cable or pulseaudio);
-* player - This section sets the configuration for the player such as default volume, maximum volume, etc;
-* teamtalk - here are main options for bot to connect and login to your TeamTalk server;
-* Services - Here you should configure available services for music search and playback;
-* logger - Here you can configure various logging related options.
+* `language` - Bot interface language (requires matching locale folder);
+* `sound devices` - Audio device numbers (connect output to input via virtual cable or pulseaudio);
+* `player` - Player settings: default volume, max volume, bass boost, etc;
+* `teamtalk` - TeamTalk server connection and login settings;
+* `services` - Configure available music search/playback services;
+* `logger` - Logging configuration.
 
 ## Pulse audio or VB cable settings
-### Linux variant
-* Install pulseaudio.
-* type $pulseaudio --start
-* Next command creates null sink and this sink can be monitored by default pulse input device.
-$pacmd load-module module-null-sink
-* then run ./TTMediaBot.sh --devices and check its numbers.
-output should be null audio output, input should be pulse.
-* put this numbers to your config.json.
+### Linux
+* Install pulseaudio, then:
+```sh
+pulseaudio --start
+pacmd load-module module-null-sink
+```
+* Run `./TTMediaBot.sh --devices` — output should be "null audio output", input should be "pulse".
 
-### windows variant
-* install VB-cable, run "TTMediaBot.py --devices" and check numbers of VB-cable devices
-* put this numbers to your config.json.
-
-## Some notes about the Windows variant
-* When listing input and output devices in the Windows variant of TTMediaBot, please note, that the input device will be doubled, i.e., if the output device is line 1 with number 3, the input device for line 1 will be listed twice, at number 5 and, for example, at number 7.
-* The correct number will be the last one as input, that is, if we selected the output as line 1 with the number 3, the input device would be line 1 with number 7 of the two options, number 5 and number 7.
-* The same method applies to all numbers and all Input / Outputs.
-
-# support us
-* yoomoney: https://yoomoney.ru/to/4100117354062028
-
-# contacts
-* telegram channel: https://t.me/TTMediaBot_chat
-* E-mail: TTMediaBot@gmail.com
+### Windows
+* Install VB-Cable, run `python TTMediaBot.py --devices`, and use the correct device numbers.
+* Note: input device numbers may be duplicated — always pick the highest-numbered one for your output device.

--- a/TTMediaBot.sh
+++ b/TTMediaBot.sh
@@ -4,4 +4,4 @@ PROGNAME=TTMediaBot.py
 PROGDIR=$(dirname "$(readlink -f $0)")
 LD_LIBRARY_PATH=$PROGDIR/TeamTalk_DLL:$PROGDIR:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH
-python3 "$PROGDIR/$PROGNAME" "$@"
+exec python "$PROGDIR/$PROGNAME" "$@"

--- a/bot/TeamTalk/__init__.py
+++ b/bot/TeamTalk/__init__.py
@@ -192,6 +192,8 @@ class TeamTalk:
             if channel_id == 0:
                 raise ValueError()
         return self.tt.doJoinChannelByID(channel_id, _str(password))
+    def DoMoveUser(self, channel: int, usuarioid: int)->None:
+        self.tt.doMoveUser(channel, usuarioid)
 
     def change_nickname(self, nickname: str) -> None:
         self.tt.doChangeNickname(_str(nickname))

--- a/bot/TeamTalk/__init__.py
+++ b/bot/TeamTalk/__init__.py
@@ -95,6 +95,8 @@ class TeamTalk:
         self.reconnect = False
         self.reconnect_attempt = 0
         self.user_account: UserAccount
+        self._joined_channel = False  # Flag para saber se entrou no canal
+        self._ready_event = None  # Will be set after joining channel
 
     def initialize(self) -> None:
         logging.debug("Initializing TeamTalk")
@@ -139,8 +141,11 @@ class TeamTalk:
         else:
             channel_id = self.tt.getChannelIDFromPath(_str(self.config.channel))
             if channel_id == 0:
+                logging.warning(f"Channel '{self.config.channel}' not found, falling back to channel 1")
                 channel_id = 1
+        logging.info(f"Joining channel ID: {channel_id}")
         self.tt.doJoinChannelByID(channel_id, _str(self.config.channel_password))
+        self._joined_channel = False  # Será definido como True no evento CMD_JOINED_CHANNEL
 
     @property
     def default_status(self) -> str:

--- a/bot/TeamTalk/thread.py
+++ b/bot/TeamTalk/thread.py
@@ -30,6 +30,7 @@ class TeamTalkThread(Thread):
         if self.config.event_handling.load_event_handlers:
             self.event_handlers = self.import_event_handlers()
         self._close = False
+        logging.info("TeamTalk thread started")
         while not self._close:
             event = self.ttclient.get_event(self.ttclient.tt.getMessage())
             if event.event_type == EventType.NONE:
@@ -38,6 +39,7 @@ class TeamTalkThread(Thread):
                 event.event_type == EventType.ERROR
                 and self.ttclient.state == State.CONNECTED
             ):
+                logging.warning(f"TeamTalk error: {event.error}")
                 self.ttclient.errors_queue.put(event.error)
             elif (
                 event.event_type == EventType.SUCCESS
@@ -74,45 +76,50 @@ class TeamTalkThread(Thread):
                     or self.config.reconnection_attempts < 0
                 ):
                     self.ttclient.disconnect()
+                    logging.info(f"Reconnecting in {self.config.reconnection_timeout} seconds...")
                     time.sleep(self.config.reconnection_timeout)
                     self.ttclient.connect()
                     self.ttclient.reconnect_attempt += 1
                 else:
-                    logging.error("Connection error")
+                    logging.error("Connection error - exiting")
                     sys.exit(1)
             elif event.event_type == EventType.CON_SUCCESS:
                 self.ttclient.reconnect_attempt = 0
+                logging.info("Connection successful, logging in...")
                 self.ttclient.login()
             elif event.event_type == EventType.ERROR:
                 if self.ttclient.flags & Flags.AUTHORIZED == Flags(0):
-                    logging.warning("Login failed")
+                    logging.warning(f"Login failed: {event.error}")
                     if (
                         self.ttclient.reconnect
                         and self.ttclient.reconnect_attempt
                         < self.config.reconnection_attempts
                         or self.config.reconnection_attempts < 0
                     ):
+                        logging.info(f"Retrying login in {self.config.reconnection_timeout} seconds...")
                         time.sleep(self.config.reconnection_timeout)
                         self.ttclient.login()
                     else:
-                        logging.error("Login error")
+                        logging.error("Login error - exiting")
                         sys.exit(1)
                 else:
-                    logging.warning("Failed to join channel")
+                    logging.warning(f"Failed to join channel: {event.error}")
                     if (
                         self.ttclient.reconnect
                         and self.ttclient.reconnect_attempt
                         < self.config.reconnection_attempts
                         or self.config.reconnection_attempts < 0
                     ):
+                        logging.info(f"Retrying to join channel in {self.config.reconnection_timeout} seconds...")
                         time.sleep(self.config.reconnection_timeout)
                         self.ttclient.join()
                     else:
-                        logging.error("Error joining channel")
+                        logging.error("Error joining channel - exiting")
                         sys.exit(1)
             elif event.event_type == EventType.MYSELF_LOGGEDIN:
                 self.ttclient.user_account = event.user_account
                 self.ttclient.reconnect_attempt = 0
+                logging.info("Logged in successfully, joining channel...")
                 self.ttclient.join()
             elif (
                 event.event_type == EventType.SUCCESS
@@ -121,7 +128,10 @@ class TeamTalkThread(Thread):
                 self.ttclient.reconnect_attempt = 0
                 self.ttclient.reconnect = True
                 self.ttclient.state = State.CONNECTED
+                self.ttclient._joined_channel = True  # Marcou como Connected = está no canal
                 self.ttclient.change_status_text(self.ttclient.status)
+                current_channel = self.ttclient.channel
+                logging.info(f"Connected to server and joined channel: {current_channel.name} (ID: {current_channel.id})")
             if self.config.event_handling.load_event_handlers:
                 self.run_event_handler(event)
 

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -92,12 +92,28 @@ class Bot:
         self.tt_player_connector.start()
         self.command_processor.run()
         logging.info("Started")
+
+        # Esperar estar conectado E no canal antes de processar comandos de startup
+        logging.info("Waiting to join channel...")
+        max_wait = 30  # segundos máximos de espera
+        waited = 0
+        while not self.ttclient._joined_channel and waited < max_wait:
+            time.sleep(1)
+            waited += 1
+            if waited % 5 == 0:
+                logging.debug(f"Still waiting to join channel... ({waited}/{max_wait}s)")
+
+        if not self.ttclient._joined_channel:
+            logging.error("Timed out waiting to join channel!")
+        else:
+            logging.info(f"Successfully joined channel after {waited} seconds")
+
         logging.info(f"Processing {len(self.config.general.start_commands)} startup command(s)...")
         startup_context_user = User(
-            id=-1, nickname="Startup", username="", 
-            channel=self.ttclient.channel, 
-            type=UserType.Admin, is_admin=True, 
-            status="", gender=UserStatusMode.N, state=UserState.Null, 
+            id=-1, nickname="Startup", username="",
+            channel=self.ttclient.channel,
+            type=UserType.Admin, is_admin=True,
+            status="", gender=UserStatusMode.N, state=UserState.Null,
             client_name="", version=0, user_account=None, is_banned=False
         )
         for command in self.config.general.start_commands:

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -130,10 +130,11 @@ class Bot:
                 pass
         self._close = False
         while not self._close:
-            if self.config.general.back_to_root_channel and len(self.ttclient.tt.getChannelUsers(self.ttclient.channel.id))==1 and self.ttclient.channel.id!=1:
+            root_channel_id = self.config.general.root_channel_id
+            if self.config.general.back_to_root_channel and len(self.ttclient.tt.getChannelUsers(self.ttclient.channel.id))==1 and self.ttclient.channel.id != root_channel_id:
                 if self.player.state != State.Stopped:
                     self.player.stop()
-                self.ttclient.DoMoveUser(self.ttclient.user.id, 1)
+                self.ttclient.DoMoveUser(self.ttclient.user.id, root_channel_id)
             try:
                 message = self.ttclient.message_queue.get_nowait()
                 logging.info(

--- a/bot/app_vars.py
+++ b/bot/app_vars.py
@@ -17,7 +17,7 @@ License: Mit License\
 """
 )
 fallback_service = "yt"
-loop_timeout = 0.01
+loop_timeout = 0.1
 max_message_length = 256
 recents_max_lenth = 32
 tt_event_timeout = 2

--- a/bot/app_vars.py
+++ b/bot/app_vars.py
@@ -10,10 +10,24 @@ app_version = "2.3.1"
 client_name = app_name + "-V" + app_version
 about_text: Callable[[Translator], str] = lambda translator: translator.translate(
     """\
-A media streaming bot for TeamTalk.
-Authors: Amir Gumerov, Vladislav Kopylov, Beqa Gozalishvili, Kirill Belousov.
-Home page: https://github.com/gumerov-amir/TTMediaBot\
-License: Mit License\
+TTMediaBot-V4.0
+Olá! Eu sou Nuno Costa. Este é o meu fork do TTMediaBot para TeamTalk 5.
+Este repositório foca em estabilidade, performance e suporte para YouTube Music.
+Repositório: https://www.github.com/nunotfc/TTMediaBot
+
+Diferenças em relação ao original:
+- Comando de fila (queue): modo de reprodução em fila com enfileiramento de tracks
+- Comando /update: verifica e instala atualizações pip, reinicia o bot automaticamente
+- Comando /bb: bass boost ajustável (0-10)
+- Comando /pi: pitch control (-12 a +12 semitons)
+- Comando /ep: salvar posição de reprodução ao pausar/parar
+- Comandos encadeados com | (ex: t | v 30)
+- Cache separada em arquivos (recents.dat, favorites.dat, queue.dat, meta.json)
+- Correções de memory leak, uso de CPU e race condition na inicialização
+- Resiliência: cache corrompido não crasha o bot
+- Suporte a Dropbox como serviço de stream
+
+Autores Originais: Amir Gumerov, Vladislav Kopylov, Beqa Gozalishvili, Kirill Belousov.\
 """
 )
 fallback_service = "yt"

--- a/bot/cache.py
+++ b/bot/cache.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
+import json
+import os
 import pickle
 from collections import deque
-from typing import Any, Dict, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from bot import app_vars
 from bot.migrators import cache_migrator
-
-import portalocker
 
 if TYPE_CHECKING:
     from bot.player.track import Track
@@ -27,48 +27,97 @@ class Cache:
         self.favorites: Dict[str, List[Track]] = (
             cache_data["favorites"] if "favorites" in cache_data else {}
         )
+        self.queue: List[Track] = cache_data["queue"] if "queue" in cache_data else []
 
     @property
     def data(self):
-        return {"cache_version": self.cache_version, "recents": self.recents, "favorites": self.favorites}
+        return {
+            "cache_version": self.cache_version,
+            "recents": self.recents,
+            "favorites": self.favorites,
+            "queue": self.queue,
+        }
 
 
 class CacheManager:
-    version = 1
+    version = 4
 
     def __init__(self, file_name: str) -> None:
-        self.file_name = file_name
+        self.original_file_name = os.path.abspath(file_name)
+        self._prepare_paths(file_name)
+        self._ensure_cache_dir()
         try:
-            self.data = cache_migrator.migrate(self, self._load())
-            self.cache = Cache(self.data)
+            data = cache_migrator.migrate(self, self._load())
+            self.cache = Cache(data)
         except FileNotFoundError:
             self.cache = Cache({})
             self._dump(self.cache.data)
-        self._lock()
+        else:
+            self._dump(self.cache.data)
+
+    def _prepare_paths(self, file_name: str) -> None:
+        abs_path = os.path.abspath(file_name)
+        if os.path.isdir(abs_path):
+            self.cache_dir = abs_path
+        else:
+            base_dir = os.path.splitext(abs_path)[0]
+            self.cache_dir = base_dir
+        self.recents_file = os.path.join(self.cache_dir, "recents.dat")
+        self.favorites_file = os.path.join(self.cache_dir, "favorites.dat")
+        self.queue_file = os.path.join(self.cache_dir, "queue.dat")
+        self.meta_file = os.path.join(self.cache_dir, "meta.json")
 
     def _dump(self, data: cache_data_type):
-        with open(self.file_name, "wb") as f:
-            pickle.dump(data, f)
+        os.makedirs(self.cache_dir, exist_ok=True)
+        with open(self.recents_file, "wb") as f:
+            pickle.dump(data.get("recents", deque(maxlen=app_vars.recents_max_lenth)), f)
+        with open(self.favorites_file, "wb") as f:
+            pickle.dump(data.get("favorites", {}), f)
+        with open(self.queue_file, "wb") as f:
+            pickle.dump(data.get("queue", []), f)
+        with open(self.meta_file, "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "cache_version": data.get("cache_version", self.version),
+                },
+                f,
+            )
 
     def _load(self) -> cache_data_type:
-        with open(self.file_name, "rb") as f:
+        try:
+            return self._load_split()
+        except FileNotFoundError:
+            return self._load_single()
+
+    def _load_split(self) -> cache_data_type:
+        with open(self.meta_file, "r", encoding="utf-8") as f:
+            try:
+                meta = json.load(f)
+            except Exception:
+                f.seek(0)
+                meta = pickle.load(f)
+        with open(self.recents_file, "rb") as f:
+            recents = pickle.load(f)
+        with open(self.favorites_file, "rb") as f:
+            favorites = pickle.load(f)
+        with open(self.queue_file, "rb") as f:
+            queue = pickle.load(f)
+        return {
+            "cache_version": meta.get("cache_version", self.version),
+            "recents": recents,
+            "favorites": favorites,
+            "queue": queue,
+        }
+
+    def _load_single(self) -> cache_data_type:
+        with open(self.original_file_name, "rb") as f:
             return pickle.load(f)
 
-    def _lock(self):
-        self.file_locker = portalocker.Lock(
-            self.file_name,
-            timeout=0,
-            flags=portalocker.LOCK_EX | portalocker.LOCK_NB,
-        )
-        try:
-            self.file_locker.acquire()
-        except portalocker.exceptions.LockException:
-            raise PermissionError()
+    def _ensure_cache_dir(self):
+        os.makedirs(self.cache_dir, exist_ok=True)
 
     def close(self):
-        self.file_locker.release()
+        pass
 
     def save(self):
-        self.file_locker.release()
         self._dump(self.cache.data)
-        self.file_locker.acquire()

--- a/bot/cache.py
+++ b/bot/cache.py
@@ -14,20 +14,37 @@ if TYPE_CHECKING:
 
 
 cache_data_type = Dict[str, Any]
+MAX_QUEUE_SIZE = 1000
 
 
 class Cache:
     def __init__(self, cache_data: cache_data_type):
         self.cache_version = cache_data["cache_version"] if "cache_version" in cache_data else CacheManager.version
+        # Corrigir bug: garantir que recents seja sempre deque com maxlen
         self.recents: deque[Track] = (
-            cache_data["recents"]
+            deque(cache_data["recents"], maxlen=app_vars.recents_max_lenth)
             if "recents" in cache_data
             else deque(maxlen=app_vars.recents_max_lenth)
         )
         self.favorites: Dict[str, List[Track]] = (
             cache_data["favorites"] if "favorites" in cache_data else {}
         )
-        self.queue: List[Track] = cache_data["queue"] if "queue" in cache_data else []
+        # Limitar queue ao carregar
+        self.queue: List[Track] = (
+            cache_data["queue"][:MAX_QUEUE_SIZE] if "queue" in cache_data else []
+        )
+
+    def add_to_queue(self, track: "Track") -> None:
+        """Adiciona track à queue respeitando o limite MAX_QUEUE_SIZE."""
+        self.queue.append(track)
+        if len(self.queue) > MAX_QUEUE_SIZE:
+            self.queue.pop(0)  # Remove o mais antigo (FIFO)
+
+    def extend_queue(self, tracks: List["Track"]) -> None:
+        """Adiciona múltiplos tracks à queue respeitando o limite."""
+        self.queue.extend(tracks)
+        if len(self.queue) > MAX_QUEUE_SIZE:
+            self.queue = self.queue[-MAX_QUEUE_SIZE:]  # Mantém apenas os mais recentes
 
     @property
     def data(self):

--- a/bot/cache.py
+++ b/bot/cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import pickle
 from collections import deque
@@ -113,12 +114,28 @@ class CacheManager:
             except Exception:
                 f.seek(0)
                 meta = pickle.load(f)
-        with open(self.recents_file, "rb") as f:
-            recents = pickle.load(f)
-        with open(self.favorites_file, "rb") as f:
-            favorites = pickle.load(f)
-        with open(self.queue_file, "rb") as f:
-            queue = pickle.load(f)
+
+        try:
+            with open(self.recents_file, "rb") as f:
+                recents = pickle.load(f)
+        except (EOFError, pickle.UnpicklingError, Exception) as e:
+            logging.warning(f"Failed to load recents.dat, using empty: {e}")
+            recents = deque(maxlen=app_vars.recents_max_lenth)
+
+        try:
+            with open(self.favorites_file, "rb") as f:
+                favorites = pickle.load(f)
+        except (EOFError, pickle.UnpicklingError, Exception) as e:
+            logging.warning(f"Failed to load favorites.dat, using empty: {e}")
+            favorites = {}
+
+        try:
+            with open(self.queue_file, "rb") as f:
+                queue = pickle.load(f)
+        except (EOFError, pickle.UnpicklingError, Exception) as e:
+            logging.warning(f"Failed to load queue.dat, using empty: {e}")
+            queue = []
+
         return {
             "cache_version": meta.get("cache_version", self.version),
             "recents": recents,

--- a/bot/commands/__init__.py
+++ b/bot/commands/__init__.py
@@ -80,8 +80,9 @@ class CommandProcessor:
             "qq": admin_commands.QuitCommand,
             "quit": admin_commands.QuitCommand,
             "gcid": admin_commands.GetChannelIDCommand,
-    "sm": admin_commands.OptionShowMetaCommand,
-    "br": admin_commands.OptionBackToRootChannelCommand,
+            "sm": admin_commands.OptionShowMetaCommand,
+            "br": admin_commands.OptionBackToRootChannelCommand,
+            "backc": admin_commands.SetRootChannelCommand,
             "update": admin_commands.UpdateCommand,
             "upd": admin_commands.UpdateCommand,
         }

--- a/bot/commands/__init__.py
+++ b/bot/commands/__init__.py
@@ -50,6 +50,7 @@ class CommandProcessor:
             "v": user_commands.VolumeCommand,
             "mu": user_commands.MuteCommand,
             "sp": user_commands.SpeedCommand,
+            "pi": user_commands.PitchCommand,
             "ep": user_commands.EnablePositionsCommand,
             "bb": user_commands.BassBoostCommand,
             "f": user_commands.FavoritesCommand,
@@ -146,7 +147,10 @@ class CommandProcessor:
                 raise errors.AccessDeniedError(
                     self.translator.translate("You are banned"),
                 )
-            elif user.channel.id != self.ttclient.channel.id:
+            if command == "go":
+                return True
+
+            elif user.channel.id != self.ttclient.channel.id and command != "go":
                 raise errors.AccessDeniedError(
                     self.translator.translate("You are not in bot's channel"),
                 )

--- a/bot/commands/__init__.py
+++ b/bot/commands/__init__.py
@@ -82,6 +82,8 @@ class CommandProcessor:
             "gcid": admin_commands.GetChannelIDCommand,
     "sm": admin_commands.OptionShowMetaCommand,
     "br": admin_commands.OptionBackToRootChannelCommand,
+            "update": admin_commands.UpdateCommand,
+            "upd": admin_commands.UpdateCommand,
         }
 
     def run(self):

--- a/bot/commands/admin_commands.py
+++ b/bot/commands/admin_commands.py
@@ -13,6 +13,35 @@ from bot import app_vars, errors
 if TYPE_CHECKING:
     from bot.TeamTalk.structs import User
 
+class OptionShowMetaCommand(Command):
+    @property
+    def help(self) -> str:
+        return self.translator.translate(
+            "Toggles metadata display in the status message."
+        )
+
+    def __call__(self, arg: str, user: User) -> Optional[str]:
+        if self.config.general.showmeta:
+            self.config.general.showmeta = False
+            return self.translator.translate("Metadata display disabled.")
+        else:
+            self.config.general.showmeta = True
+            return self.translator.translate("Metadata display enabled.")
+
+class OptionBackToRootChannelCommand(Command):
+    @property
+    def help(self) -> str:
+        return self.translator.translate(
+            "Toggles the ability for users to move the bot to their channels automatically."
+        )
+
+    def __call__(self, arg: str, user: User) -> Optional[str]:
+        if self.config.general.back_to_root_channel:
+            self.config.general.back_to_root_channel = False
+            return self.translator.translate("Users can't move the bot to their channels.")
+        else:
+            self.config.general.back_to_root_channel = True
+            return self.translator.translate("Users can move the bot to their channels.")
 
 class BlockCommandCommand(Command):
     @property
@@ -101,13 +130,15 @@ class ClearCacheCommand(Command):
     @property
     def help(self) -> str:
         return self.translator.translate(
-            "r/f Clears bot's cache. r clears recents, f clears favorites, without an option clears the entire cache"
+            "r/f/q/p Clears bot's cache. r clears recents, f clears favorites, q clears the queue, p clears saved positions, without an option clears the entire cache"
         )
 
     def __call__(self, arg: str, user: User) -> Optional[str]:
         if not arg:
             self.cache.recents.clear()
             self.cache.favorites.clear()
+            self.cache.queue.clear()
+            self.cache.positions.clear()
             self.cache_manager.save()
             return self.translator.translate("Cache cleared")
         elif arg == "r":
@@ -118,6 +149,19 @@ class ClearCacheCommand(Command):
             self.cache.favorites.clear()
             self.cache_manager.save()
             return self.translator.translate("Favorites cleared")
+        elif arg == "q":
+            self.cache.queue.clear()
+            self.cache_manager.save()
+            return self.translator.translate("Queue cleared")
+        elif arg == "p":
+            try:
+                for track in self.cache.recents:
+                    track.resume_position = None
+                    track.resume_duration = None
+                self.cache_manager.save()
+            except Exception:
+                self.cache_manager.save()
+            return self.translator.translate("Positions cleared")
 
 
 class JoinChannelCommand(Command):

--- a/bot/commands/admin_commands.py
+++ b/bot/commands/admin_commands.py
@@ -44,6 +44,21 @@ class OptionBackToRootChannelCommand(Command):
             self.config.general.back_to_root_channel = True
             return self.translator.translate("Users can move the bot to their channels.")
 
+
+class SetRootChannelCommand(Command):
+    @property
+    def help(self) -> str:
+        return self.translator.translate(
+            "Sets the current bot channel as the return channel used by the go command."
+        )
+
+    def __call__(self, arg: str, user: User) -> Optional[str]:
+        self.config.general.root_channel_id = self.ttclient.channel.id
+        self.config.general.back_to_root_channel = True
+        return self.translator.translate(
+            "Return channel set to the current channel ID: {channel_id}."
+        ).format(channel_id=self.config.general.root_channel_id)
+
 class BlockCommandCommand(Command):
     @property
     def help(self) -> str:

--- a/bot/commands/admin_commands.py
+++ b/bot/commands/admin_commands.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import json
 import os
 import subprocess
 import sys
@@ -427,3 +428,83 @@ class GetChannelIDCommand(Command):
 
     def __call__(self, arg: str, user: User) -> Optional[str]:
         return str(self.ttclient.channel.id)
+
+
+class UpdateCommand(Command):
+    @property
+    def help(self) -> str:
+        return self.translator.translate("Checks for updates and restarts the bot if packages are updated")
+
+    def __call__(self, arg: str, user: User) -> Optional[str]:
+        # Enviar mensagem de que está verificando
+        self.ttclient.send_message(
+            self.translator.translate("Checking for updates..."),
+            user
+        )
+
+        # Capturar versões atuais
+        old_packages = self._get_installed_packages()
+
+        # Executar upgrade
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "install", "-r", "requirements.txt", "--upgrade"],
+            capture_output=True,
+            text=True
+        )
+
+        if result.returncode != 0:
+            return self.translator.translate("Error updating packages: {}").format(result.stderr)
+
+        # Capturar novas versões
+        new_packages = self._get_installed_packages()
+
+        # Comparar e encontrar diferenças
+        updated = self._find_updated_packages(old_packages, new_packages)
+
+        if not updated:
+            return self.translator.translate("No updates available.")
+
+        # Format message com as atualizações
+        updates_text = self.translator.translate("Updates installed:\n{}").format(
+            "\n".join(updated)
+        )
+        self.ttclient.send_message(updates_text, user)
+
+        # Reiniciar o bot (igual ao RestartCommand)
+        self._bot.close()
+        args = sys.argv
+        if sys.platform == "win32":
+            subprocess.run([sys.executable] + args)
+        else:
+            args.insert(0, sys.executable)
+            os.execv(sys.executable, args)
+        return None
+
+    def _get_installed_packages(self) -> dict:
+        """Retorna dict com nome do pacote -> versão"""
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "list", "--format=json"],
+            capture_output=True,
+            text=True
+        )
+        if result.returncode == 0:
+            packages = json.loads(result.stdout)
+            return {pkg["name"].lower(): pkg["version"] for pkg in packages}
+        return {}
+
+    def _find_updated_packages(self, old: dict, new: dict) -> list:
+        """Retorna lista de mensagens descrevendo as atualizações"""
+        updated = []
+        for name, old_version in old.items():
+            new_version = new.get(name)
+            if new_version and new_version != old_version:
+                # Formatar mensagem tipo "Atualizado yt-dlp de 2024.1.1 para 2024.2.1"
+                msg = self.translator.translate(
+                    "Updated {package} from {old_version} to {new_version}"
+                ).format(
+                    package=name,
+                    old_version=old_version,
+                    new_version=new_version
+                )
+                updated.append(msg)
+        return updated

--- a/bot/commands/command.py
+++ b/bot/commands/command.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import time
 from typing import Any, TYPE_CHECKING, Callable
 
 from bot.commands.task_processor import Task
+from bot.player.enums import TrackType
 
 if TYPE_CHECKING:
     from bot.commands import CommandProcessor
@@ -29,3 +31,76 @@ class Command:
 
     def run_async(self, func: Callable[..., None], *args: Any, **kwargs: Any) -> None:
         self._task_processor.task_queue.put(Task(id(self), func, args, kwargs))
+
+    def _report_position(self, user: "User", action: str) -> None:
+        try:
+            position = float(self.player._player.time_pos or 0)
+            duration_value = self.player._player.duration
+            duration = float(duration_value) if duration_value else 0
+            track = self.player.track
+            saved = False
+            if track and track.url and track.type != TrackType.Live:
+                if self.config.general.enable_positions:
+                    # set on current track
+                    track.resume_position = position
+                    track.resume_duration = duration
+                    # update matching entry in recents
+                    try:
+                        for i, recent_track in enumerate(reversed(self.cache.recents)):
+                            if recent_track.url == track.url:
+                                recent_track.resume_position = position
+                                recent_track.resume_duration = duration
+                                break
+                    except Exception:
+                        ...
+                    try:
+                        self.cache_manager.save()
+                        saved = True
+                    except Exception as e:
+                        saved = False
+                        fail_msg = f"save error: {e}"
+                else:
+                    saved = False
+            if saved:
+                msg = self.translator.translate(
+                    "Position {action}: {pos:.1f}s of {duration}"
+                ).format(
+                    action=action,
+                    pos=position,
+                    duration=duration,
+                )
+            else:
+                extra = f" ({fail_msg})" if "fail_msg" in locals() else ""
+                msg = self.translator.translate(
+                    "Position not saved (disabled or unsupported)"
+                ) + extra
+            self.ttclient.send_message(msg, user)
+        except Exception:
+            pass
+
+    def _save_current_position(self) -> None:
+        try:
+            if (
+                self.config.general.enable_positions
+                and self.player.state != State.Stopped
+                and self.player.track
+                and self.player.track.url
+                and self.player.track.type != TrackType.Live
+            ):
+                position = float(self.player._player.time_pos or 0)
+                duration_value = self.player._player.duration
+                duration = float(duration_value) if duration_value else 0
+                track = self.player.track
+                track.resume_position = position
+                track.resume_duration = duration
+                try:
+                    for recent_track in reversed(self.cache.recents):
+                        if recent_track.url == track.url:
+                            recent_track.resume_position = position
+                            recent_track.resume_duration = duration
+                            break
+                except Exception:
+                    ...
+                self.cache_manager.save()
+        except Exception:
+            pass

--- a/bot/commands/user_commands.py
+++ b/bot/commands/user_commands.py
@@ -565,6 +565,31 @@ class BassBoostCommand(Command):
             return self.translator.translate("Cannot set bass boost")
 
 
+class PitchCommand(Command):
+    @property
+    def help(self) -> str:
+        return self.translator.translate(
+            "SEMITONES Sets pitch from -12 to +12 semitones (one octave). 0 disables pitch shift"
+        )
+
+    def __call__(self, arg: str, user: User) -> Optional[str]:
+        if not arg:
+            return self.translator.translate("Current pitch: {semitons} semitones").format(
+                semitons=self.player.get_pitch()
+            )
+        try:
+            semitons = int(arg)
+            self.player.set_pitch(semitons)
+            if semitons == 0:
+                return self.translator.translate("Pitch shift disabled")
+            else:
+                return self.translator.translate("Pitch set to {semitons} semitones").format(
+                    semitons=semitons
+                )
+        except ValueError:
+            raise errors.InvalidArgumentError()
+
+
 class FavoritesCommand(Command):
     @property
     def help(self) -> str:
@@ -753,7 +778,7 @@ class MoveUsersCommand(Command):
         users = self.ttclient.tt.getChannelUsers(user.channel.id)
         can_move = True
         for user_entry in users:
-            if sys.version_info <= (3, 10 , 10):
+            if sys.version_info < (3, 11):
                 if "TTMediaBot" in user_entry.szClientName:
                     can_move = False
                     break

--- a/bot/commands/user_commands.py
+++ b/bot/commands/user_commands.py
@@ -126,7 +126,7 @@ class PlayPauseCommand(Command):
                     if not track_list:
                         raise errors.NothingFoundError()
                     track = track_list[0].get_raw()
-                    self.cache.queue.append(track)
+                    self.cache.add_to_queue(track)
                     self.cache_manager.save()
                     if self.config.general.send_channel_messages:
                         self.run_async(
@@ -191,8 +191,9 @@ class PlayUrlCommand(Command):
             try:
                 tracks = self.module_manager.streamer.get(arg, user.is_admin)
                 if self.player.mode == Mode.Queue:
-                    for track in tracks:
-                        self.cache.queue.append(track.get_raw())
+                    # Converter tracks para raw e adicionar de uma vez
+                    raw_tracks = [track.get_raw() for track in tracks]
+                    self.cache.extend_queue(raw_tracks)
                     self.cache_manager.save()
                     if self.config.general.send_channel_messages:
                         self.run_async(

--- a/bot/commands/user_commands.py
+++ b/bot/commands/user_commands.py
@@ -789,7 +789,8 @@ class MoveUsersCommand(Command):
                     break
         if not can_move:
             return self.translator.translate("There is already a bot on this channel.")
-        if self.ttclient.channel.id!=1:return self.translator.translate("I'm not on the root channel.")
+        if self.ttclient.channel.id != self.config.general.root_channel_id:
+            return self.translator.translate("I'm not on the root channel.")
         self.ttclient.DoMoveUser(self.ttclient.user.id, user.channel.id)
         return self.translator.translate("Ready, I'm at your disposal. But remember. If there are no users in the channel other than me, I'll go back to the home channel.")
 

--- a/bot/config/__init__.py
+++ b/bot/config/__init__.py
@@ -18,7 +18,7 @@ def save_default_file() -> None:
 
 
 class ConfigManager:
-    version = 1
+    version = 3
 
     def __init__(self, file_name: Optional[str]) -> None:
         if file_name:

--- a/bot/config/models.py
+++ b/bot/config/models.py
@@ -6,6 +6,10 @@ from pydantic import BaseModel
 class GeneralModel(BaseModel):
     language: str = "en"
     send_channel_messages: bool = True
+    back_to_root_channel: bool = True
+    showmeta: bool = True
+    enable_positions: bool = False
+
     cache_file_name: str = "TTMediaBotCache.dat"
     blocked_commands: List[str] = []
     delete_uploaded_files_after: int = 300
@@ -24,6 +28,7 @@ class PlayerModel(BaseModel):
     volume_fading_interval: float = 0.025
     seek_step: int = 5
     player_options: Dict[str, Any] = {}
+    bass_boost_level: int = 0
 
 class TeamTalkUserModel(BaseModel):
     admins: List[str] = ["admin"]
@@ -60,8 +65,6 @@ class VkModel(BaseModel):
     token: str = ""
 
 
-class YtModel(BaseModel):
-    enabled: bool = True
 class YtModel(BaseModel):
     enabled: bool = True
     cookiefile_path: str = ""

--- a/bot/config/models.py
+++ b/bot/config/models.py
@@ -75,11 +75,16 @@ class YamModel(BaseModel):
     token: str = ""
 
 
+class DropboxModel(BaseModel):
+    enabled: bool = True
+
+
 class ServicesModel(BaseModel):
     default_service: str = "vk"
     vk: VkModel = VkModel()
     yam: YamModel = YamModel()
     yt: YtModel = YtModel()
+    dropbox: DropboxModel = DropboxModel()
 
 
 class LoggerModel(BaseModel):

--- a/bot/config/models.py
+++ b/bot/config/models.py
@@ -7,6 +7,7 @@ class GeneralModel(BaseModel):
     language: str = "en"
     send_channel_messages: bool = True
     back_to_root_channel: bool = True
+    root_channel_id: int = 1
     showmeta: bool = True
     enable_positions: bool = False
 

--- a/bot/logger.py
+++ b/bot/logger.py
@@ -56,4 +56,4 @@ def initialize_logger(bot: Bot) -> None:
         stream_handler.setFormatter(formatter)
         stream_handler.setLevel(level)
         handlers.append(stream_handler)
-    logging.basicConfig(level=level, format=config.format, handlers=handlers)
+    logging.basicConfig(level=level, format=config.format, handlers=handlers, force=True)

--- a/bot/migrators/cache_migrator.py
+++ b/bot/migrators/cache_migrator.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import sys
 from typing import TYPE_CHECKING
 
-
 if TYPE_CHECKING:
     from bot.cache import CacheManager, cache_data_type
 
@@ -12,7 +11,26 @@ def to_v1(cache_data: cache_data_type) -> cache_data_type:
     return update_version(cache_data, 1)
 
 
-migrate_functs = {1: to_v1}
+def to_v2(cache_data: cache_data_type) -> cache_data_type:
+    if "queue" not in cache_data:
+        cache_data["queue"] = []
+    cache_data.pop("queue_mode", None)
+    return update_version(cache_data, 2)
+
+
+def to_v3(cache_data: cache_data_type) -> cache_data_type:
+    if "positions" not in cache_data:
+        cache_data["positions"] = {}
+    return update_version(cache_data, 3)
+
+migrate_functs = {1: to_v1, 2: to_v2, 3: to_v3}
+
+
+def to_v4(cache_data: cache_data_type) -> cache_data_type:
+    cache_data.pop("positions", None)
+    return update_version(cache_data, 4)
+
+migrate_functs[4] = to_v4
 
 
 def migrate(
@@ -29,7 +47,7 @@ def migrate(
     elif cache_data["cache_version"] == cache_manager.version:
         return cache_data
     else:
-        for ver in migrate_functs:
+        for ver in sorted(migrate_functs):
             if ver > cache_data["cache_version"]:
                 cache_data = migrate_functs[ver](cache_data)
         cache_manager._dump(cache_data)

--- a/bot/migrators/config_migrator.py
+++ b/bot/migrators/config_migrator.py
@@ -7,7 +7,17 @@ def to_v1(config_data: config_data_type) -> config_data_type:
     return update_version(config_data, 1)
 
 
-migrate_functs = {1: to_v1}
+def to_v2(config_data: config_data_type) -> config_data_type:
+    if "player" in config_data and "bass_boost_level" not in config_data["player"]:
+        config_data["player"]["bass_boost_level"] = 0
+    return update_version(config_data, 2)
+
+def to_v3(config_data: config_data_type) -> config_data_type:
+    if "general" in config_data and "enable_positions" not in config_data["general"]:
+        config_data["general"]["enable_positions"] = False
+    return update_version(config_data, 3)
+
+migrate_functs = {1: to_v1, 2: to_v2, 3: to_v3}
 
 
 def migrate(
@@ -15,7 +25,7 @@ def migrate(
     config_data: config_data_type,
 ) -> config_data_type:
     if "config_version" not in config_data:
-        update_version(config_data, 0)
+        config_data = update_version(config_data, 0)
     elif (
         not isinstance(config_data["config_version"], int)
         or config_data["config_version"] > config_manager.version
@@ -24,7 +34,7 @@ def migrate(
     elif config_data["config_version"] == config_manager.version:
         return config_data
     else:
-        for ver in migrate_functs:
+        for ver in sorted(migrate_functs):
             if ver > config_data["config_version"]:
                 config_data = migrate_functs[ver](config_data)
         config_manager._dump(config_data)

--- a/bot/player/__init__.py
+++ b/bot/player/__init__.py
@@ -269,20 +269,30 @@ class Player:
         except Exception:
             ...
 
+    def _update_audio_filters(self) -> None:
+        """Combine bass_boost and pitch filters into a single af string"""
+        filters = []
+        # Add bass boost filter if active
+        if self.bass_boost_level > 0:
+            gain = (self.bass_boost_level * 60) // 100 - 30
+            filters.append(f"bass=g={gain}")
+        # Add pitch filter if active
+        pitch = self.get_pitch()
+        if pitch != 0:
+            sample_rate = 48000
+            pitch_factor = 2.0 ** (pitch / 12.0)
+            filters.append(f"lavfi=[asetrate={sample_rate}*{pitch_factor},aresample={sample_rate}]")
+        # Set combined filters
+        if filters:
+            self._player.af = ",".join(filters)
+        else:
+            self._player.af = ""
+
     def set_bass_boost(self, level: int) -> None:
         if level < 0 or level > 100:
             raise ValueError()
-        self._clear_bass_boost()
-        self.bass_boost_level = 0
-        if level == 0:
-            self._player.af = ""
-            return
-        gain = (level * 60) // 100 - 30
-        try:
-            self._player.af = f"bass=g={gain}"
-        except Exception:
-            raise errors.ServiceError("Cannot set bass boost")
         self.bass_boost_level = level
+        self._update_audio_filters()
         try:
             self.config.bass_boost_level = level
         except Exception:
@@ -295,6 +305,15 @@ class Player:
         if arg < 0.25 or arg > 4:
             raise ValueError()
         self._player.speed = arg
+
+    def get_pitch(self) -> int:
+        return getattr(self, '_pitch', 0)
+
+    def set_pitch(self, semitons: int) -> None:
+        if semitons < -12 or semitons > 12:
+            raise ValueError()
+        self._pitch = semitons
+        self._update_audio_filters()
 
     def seek_back(self, step: Optional[float] = None) -> None:
         step = step if step else self.config.seek_step

--- a/bot/player/__init__.py
+++ b/bot/player/__init__.py
@@ -28,9 +28,8 @@ class Player:
         self.cache_manager = bot.cache_manager
         mpv_options = {
             "demuxer_lavf_o": "http_persistent=false",
-            "demuxer_max_back_bytes": 0,  # Sem buffer trás
-            "demuxer_max_bytes": 640000,  # ~640KB (~5 segundos a 128kbps)
-            "cache_secs": 5,  # 5 segundos de buffer para todos os streams
+            "demuxer_max_back_bytes": 1048576,
+            "demuxer_max_bytes": 2097152,
             "video": False,
             "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36",
             "ytdl": False,

--- a/bot/player/__init__.py
+++ b/bot/player/__init__.py
@@ -17,6 +17,9 @@ if TYPE_CHECKING:
     from bot import Bot
 
 
+MAX_TRACK_LIST_SIZE = 1000
+
+
 class Player:
     def __init__(self, bot: Bot):
         self.config = bot.config.player
@@ -25,8 +28,9 @@ class Player:
         self.cache_manager = bot.cache_manager
         mpv_options = {
             "demuxer_lavf_o": "http_persistent=false",
-            "demuxer_max_back_bytes": 1048576,
-            "demuxer_max_bytes": 2097152,
+            "demuxer_max_back_bytes": 0,  # Sem buffer trás
+            "demuxer_max_bytes": 640000,  # ~640KB (~5 segundos a 128kbps)
+            "cache_secs": 5,  # 5 segundos de buffer para todos os streams
             "video": False,
             "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36",
             "ytdl": False,
@@ -86,7 +90,11 @@ class Player:
             self._save_position_marker()
         self._queue_active_track = False
         if tracks != None:
+            # Limitar track_list para evitar consumo excessivo de RAM
+            if len(tracks) > MAX_TRACK_LIST_SIZE:
+                tracks = tracks[:MAX_TRACK_LIST_SIZE]
             self.track_list = tracks
+
             if not start_track_index and self.mode == Mode.Random:
                 self.shuffle(True)
                 self.track_index = self._index_list[0]

--- a/bot/player/enums.py
+++ b/bot/player/enums.py
@@ -13,6 +13,7 @@ class Mode(Enum):
     TrackList = "tl"
     RepeatTrackList = "rtl"
     Random = "rnd"
+    Queue = "q"
 
 
 class TrackType(Enum):

--- a/bot/player/track.py
+++ b/bot/player/track.py
@@ -30,6 +30,8 @@ class Track:
         self.format = format
         self.extra_info = extra_info
         self.type = type
+        self.resume_position: Optional[float] = None
+        self.resume_duration: Optional[float] = None
         self._lock = Lock()
         self._is_fetched = False
 

--- a/bot/player/track.py
+++ b/bot/player/track.py
@@ -88,7 +88,21 @@ class Track:
         if hasattr(self, "_original_track"):
             return self._original_track
         else:
-            return self
+            # Retornar uma cópia rasa para evitar memory leak
+            # Sem isso, recents/favorites/queue mantêm referência aos tracks da track_list,
+            # impedindo que sejam liberados pelo garbage collector
+            raw = Track(
+                service=self.service,
+                url=self._url if hasattr(self, '_url') else self.url,
+                name=self._name if hasattr(self, '_name') else self.name,
+                format=self.format,
+                extra_info=self.extra_info,
+                type=self.type
+            )
+            raw.resume_position = self.resume_position
+            raw.resume_duration = self.resume_duration
+            raw._is_fetched = self._is_fetched
+            return raw
 
     def __bool__(self):
         if self.service or self.url:

--- a/bot/services/__init__.py
+++ b/bot/services/__init__.py
@@ -45,6 +45,7 @@ class Service(ABC):
 from bot.services.vk import VkService
 from bot.services.yam import YamService
 from bot.services.yt import YtService
+from bot.services.dropbox import DropboxService
 
 
 class ServiceManager:
@@ -53,7 +54,9 @@ class ServiceManager:
         self.services: Dict[str, Service] = {
             "vk": VkService(bot, self.config.vk),
             "yam": YamService(bot, self.config.yam),
+            "dropbox": DropboxService(bot, self.config.dropbox),
             "yt": YtService(bot, self.config.yt),
+            "dropbox": DropboxService(bot, self.config.dropbox),
         }
         self.service: Service = self.services[self.config.default_service]
         self.fallback_service = app_vars.fallback_service

--- a/bot/services/dropbox.py
+++ b/bot/services/dropbox.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bot import Bot
+
+from bot.config.models import DropboxModel
+from bot.player.track import Track
+from bot.player.enums import TrackType
+from bot.services import Service as _Service
+
+
+class DropboxService(_Service):
+    def __init__(self, bot: Bot, config: DropboxModel) -> None:
+        self.bot = bot
+        self.config = config
+        self.name = "dropbox"
+        self.hostnames = [
+            "dropbox.com",
+            "www.dropbox.com",
+            "dropboxusercontent.com",
+        ]
+        self.is_enabled = config.enabled
+        self.error_message = ""
+        self.warning_message = ""
+        self.help = ""
+        self.hidden = False
+
+    def initialize(self) -> None:
+        pass  # Nada a inicializar
+
+    def get(
+        self,
+        url: str,
+        extra_info: Optional[Dict[str, Any]] = None,
+        process: bool = False,
+    ) -> List[Track]:
+        # Se dl=0, troca para dl=1
+        if "dl=0" in url:
+            url = url.replace("dl=0", "dl=1")
+
+        # Retorna Direct - o mpv segue o redirect automaticamente
+        return [Track(url=url, type=TrackType.Direct)]
+
+    def search(self, query: str) -> List[Track]:
+        raise NotImplementedError("Dropbox não suporta busca")

--- a/bot/services/patches.py
+++ b/bot/services/patches.py
@@ -1,0 +1,39 @@
+import inspect
+import textwrap
+
+import httpx
+import youtubesearchpython.handlers.componenthandler as ch
+
+
+def patch_httpx_post_proxies() -> None:
+    """
+    Ignore deprecated 'proxies' kwarg on httpx>=0.28 used by youtubesearchpython.
+    """
+    if "proxies" in inspect.signature(httpx.post).parameters:
+        return
+    original_post = httpx.post
+
+    def _post(*args, **kwargs):
+        kwargs.pop("proxies", None)
+        return original_post(*args, **kwargs)
+
+    httpx.post = _post
+
+
+def patch_channel_link_none() -> None:
+    """
+    Prevent TypeError when channel id is None in youtubesearchpython.
+    """
+    src = inspect.getsource(ch.ComponentHandler._getVideoComponent)
+    needle = "component['channel']['link'] = 'https://www.youtube.com/channel/' + component['channel']['id']"
+    if needle not in src:
+        return
+    patched = src.replace(
+        needle,
+        "channel_id = component.get('channel', {}).get('id')\n"
+        "        component['channel']['link'] = "
+        "('https://www.youtube.com/channel/' + channel_id) if channel_id else None",
+    )
+    ns = {}
+    exec(textwrap.dedent(patched), ch.__dict__, ns)
+    ch.ComponentHandler._getVideoComponent = ns["_getVideoComponent"]

--- a/bot/services/yt.py
+++ b/bot/services/yt.py
@@ -42,22 +42,24 @@ class YtService(_Service):
 
             "skip_download": True,
             "format": "m4a/bestaudio/best[protocol!=m3u8_native]/best",
-            "socket_timeout": 5,    
+            "socket_timeout": 5,
 #"cookiesfrombrowser": ('firefox', '', None, 'none'),
             #"cookiefile": f"{app_vars.directory}/cookies.txt",
             "logger": logging.getLogger("root"),
         }
         if self.config.cookiefile_path and os.path.isfile(self.config.cookiefile_path):
             self._ydl_config |= {"cookiefile": self.config.cookiefile_path}
+        # Criar instância única do YoutubeDL para reutilizar
+        self._ydl = YoutubeDL(self._ydl_config)
             
     def download(self, track: Track, file_path: str) -> None:
         info = track.extra_info
         if not info:
             super().download(track, file_path)
             return
-        with YoutubeDL(self._ydl_config) as ydl:
-            dl = get_suitable_downloader(info)(ydl, self._ydl_config)
-            dl.download(file_path, info)
+        # Reutilizar instância única do YoutubeDL
+        dl = get_suitable_downloader(info)(self._ydl, self._ydl_config)
+        dl.download(file_path, info)
 
     def get(
         self,
@@ -67,48 +69,48 @@ class YtService(_Service):
     ) -> List[Track]:
         if not (url or extra_info):
             raise errors.InvalidArgumentError()
-        with YoutubeDL(self._ydl_config) as ydl:
-            if not extra_info:
-                info = ydl.extract_info(url, process=False)
-            else:
-                info = extra_info
-            info_type = None
-            if "_type" in info:
-                info_type = info["_type"]
-            if info_type == "url" and not info["ie_key"]:
-                return self.get(info["url"], process=False)
-            elif info_type == "playlist":
-                tracks: List[Track] = []
-                for entry in info["entries"]:
-                    data = self.get("", extra_info=entry, process=False)
-                    tracks += data
-                return tracks
-            if not process:
-                return [
-                    Track(service=self.name, extra_info=info, type=TrackType.Dynamic)
-                ]
-            try:
-                stream = ydl.process_ie_result(info)
-            except Exception:
-                raise errors.ServiceError()
-            if "url" in stream:
-                url = stream["url"]
-            else:
-                raise errors.ServiceError()
-            title = stream["title"]
-            if "uploader" in stream:
-                title += " - {}".format(stream["uploader"])
-            format = stream["ext"]
-            if "is_live" in stream and stream["is_live"]:
-                type = TrackType.Live
-            else:
-                type = TrackType.Default
+        # Reutilizar instância única do YoutubeDL
+        if not extra_info:
+            info = self._ydl.extract_info(url, process=False)
+        else:
+            info = extra_info
+        info_type = None
+        if "_type" in info:
+            info_type = info["_type"]
+        if info_type == "url" and not info["ie_key"]:
+            return self.get(info["url"], process=False)
+        elif info_type == "playlist":
+            tracks: List[Track] = []
+            for entry in info["entries"]:
+                data = self.get("", extra_info=entry, process=False)
+                tracks += data
+            return tracks
+        if not process:
             return [
-                Track(service=self.name, url=url, name=title, format=format, type=type, extra_info=stream)
+                Track(service=self.name, extra_info=info, type=TrackType.Dynamic)
             ]
+        try:
+            stream = self._ydl.process_ie_result(info)
+        except Exception:
+            raise errors.ServiceError()
+        if "url" in stream:
+            url = stream["url"]
+        else:
+            raise errors.ServiceError()
+        title = stream["title"]
+        if "uploader" in stream:
+            title += " - {}".format(stream["uploader"])
+        format = stream["ext"]
+        if "is_live" in stream and stream["is_live"]:
+            type = TrackType.Live
+        else:
+            type = TrackType.Default
+        return [
+            Track(service=self.name, url=url, name=title, format=format, type=type, extra_info=stream)
+        ]
 
     def search(self, query: str) -> List[Track]:
-        search = VideosSearch(query, limit=300).result()
+        search = VideosSearch(query, limit=50).result()
         if search["result"]:
             tracks: List[Track] = []
             for video in search["result"]:

--- a/config_default.json
+++ b/config_default.json
@@ -3,6 +3,8 @@
     "general": {
         "language": "en",
         "send_channel_messages": true,
+        "back_to_root_channel": true,
+        "root_channel_id": 1,
         "cache_file_name": "TTMediaBotCache.dat",
         "blocked_commands": [],
         "delete_uploaded_files_after": 300,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+pulseaudio --start
+exec ./TTMediaBot.sh "$@"

--- a/downloader.py
+++ b/downloader.py
@@ -2,7 +2,10 @@ import requests
 import shutil
 
 def download_file(url: str, file_path: str) -> None:
-    headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"}
+    headers = {
+        "User-Agent": "curl/8.1.2",
+        "Accept": "*/*",
+    }
     with requests.get(url, headers=headers, stream=True) as r:
         try:
             with open(file_path, "wb") as f:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+httpx
 babel
 beautifulsoup4
 patool
@@ -8,4 +9,6 @@ requests
 vk-api
 yandex_music
 youtube-search-python
-yt-dlp
+yt-dlp-ejs
+deno
+yt-dlp>=2024.0.dev0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ youtube-search-python
 yt-dlp-ejs
 deno
 yt-dlp>=2024.0.dev0
+cloudscraper

--- a/tools/ttsdk_downloader.py
+++ b/tools/ttsdk_downloader.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
-import bs4
 import patoolib
-import requests
 
 import os
 import platform
@@ -15,7 +13,13 @@ sys.path.append(path)
 import downloader
 
 
-url = "https://bearware.dk/teamtalksdk"
+# Direct SDK URLs (v5.22a - Cloudflare blocks scraping)
+SDK_URLS = {
+    "win64": "https://www.bearware.dk/teamtalksdk/v5.22a/tt5prosdk_v5.22a_win64.7z",
+    "win32": "https://www.bearware.dk/teamtalksdk/v5.22a/tt5prosdk_v5.22a_win32.7z",
+    "ubuntu22_x86_64": "https://www.bearware.dk/teamtalksdk/v5.22a/tt5sdk_v5.22a_ubuntu22_x86_64.7z",
+    "raspbian_armhf": "https://www.bearware.dk/teamtalksdk/v5.22a/tt5sdk_v5.22a_raspbian_armhf.7z",
+}
 
 
 def get_url_suffix_from_platform() -> str:
@@ -41,43 +45,14 @@ def get_url_suffix_from_platform() -> str:
 
 
 def download() -> None:
-    headers = {
-        'User-Agent': (
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
-            'AppleWebKit/537.36 (KHTML, like Gecko) '
-            'Chrome/58.0.3029.110 Safari/537.3'
-        )
-    }
+    suffix = get_url_suffix_from_platform()
+    download_url = SDK_URLS.get(suffix)
 
-    r = requests.get(url, headers=headers)
-    page = bs4.BeautifulSoup(r.text, features="html.parser")
+    if not download_url:
+        sys.exit(f"No SDK URL available for platform: {suffix}")
 
-    # Get all <li> tags from the page
-    versions = page.find_all("li")
-
-    # Try to find 5.15 versions first
-    v515 = [i for i in versions if "5.15" in i.text and i.a and i.a.get("href").endswith("/")]
-
-    if v515:
-        version = v515[-1].a.get("href").strip("/")
-        print("Using stable 5.15 version:", version)
-    else:
-        # fallback: get the latest version listed
-        valid_versions = [i for i in versions if i.a and i.a.get("href").endswith("/")]
-        if not valid_versions:
-            sys.exit("No SDK versions found on the page.")
-        version = valid_versions[-1].a.get("href").strip("/")
-        print("5.15 not found, falling back to latest available version:", version)
-
-    download_url = (
-        url
-        + "/"
-        + version
-        + "/"
-        + "tt5sdk_{v}_{p}.7z".format(v=version, p=get_url_suffix_from_platform())
-    )
-
-    print("Downloading from " + download_url)
+    print(f"Downloading TeamTalk SDK v5.22a ({suffix})...")
+    print(f"From: {download_url}")
     downloader.download_file(download_url, os.path.join(os.getcwd(), "ttsdk.7z"))
 
 

--- a/tools/ttsdk_downloader.py
+++ b/tools/ttsdk_downloader.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import bs4
+import cloudscraper
 import patoolib
 
 import os
@@ -13,13 +15,7 @@ sys.path.append(path)
 import downloader
 
 
-# Direct SDK URLs (v5.22a - Cloudflare blocks scraping)
-SDK_URLS = {
-    "win64": "https://www.bearware.dk/teamtalksdk/v5.22a/tt5prosdk_v5.22a_win64.7z",
-    "win32": "https://www.bearware.dk/teamtalksdk/v5.22a/tt5prosdk_v5.22a_win32.7z",
-    "ubuntu22_x86_64": "https://www.bearware.dk/teamtalksdk/v5.22a/tt5sdk_v5.22a_ubuntu22_x86_64.7z",
-    "raspbian_armhf": "https://www.bearware.dk/teamtalksdk/v5.22a/tt5sdk_v5.22a_raspbian_armhf.7z",
-}
+url = "https://bearware.dk/teamtalksdk"
 
 
 def get_url_suffix_from_platform() -> str:
@@ -45,14 +41,39 @@ def get_url_suffix_from_platform() -> str:
 
 
 def download() -> None:
-    suffix = get_url_suffix_from_platform()
-    download_url = SDK_URLS.get(suffix)
+    scraper = cloudscraper.create_scraper()
+    scraper.headers.update({
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
+    })
+    r = scraper.get(url)
+    page = bs4.BeautifulSoup(r.text, features="html.parser")
 
-    if not download_url:
-        sys.exit(f"No SDK URL available for platform: {suffix}")
+    # Get all <li> tags from the page
+    versions = page.find_all("li")
 
-    print(f"Downloading TeamTalk SDK v5.22a ({suffix})...")
-    print(f"From: {download_url}")
+    # Try to find 5.15 versions first
+    v515 = [i for i in versions if "5.15" in i.text and i.a and i.a.get("href").endswith("/")]
+
+    if v515:
+        version = v515[-1].a.get("href").strip("/")
+        print("Using stable 5.15 version:", version)
+    else:
+        # fallback: get the latest version listed
+        valid_versions = [i for i in versions if i.a and i.a.get("href").endswith("/")]
+        if not valid_versions:
+            sys.exit("No SDK versions found on the page.")
+        version = valid_versions[-1].a.get("href").strip("/")
+        print("5.15 not found, falling back to latest available version:", version)
+
+    download_url = (
+        url
+        + "/"
+        + version
+        + "/"
+        + "tt5sdk_{v}_{p}.7z".format(v=version, p=get_url_suffix_from_platform())
+    )
+
+    print("Downloading from " + download_url)
     downloader.download_file(download_url, os.path.join(os.getcwd(), "ttsdk.7z"))
 
 


### PR DESCRIPTION
Overview
This PR introduces queue-based playback, optional resume positions, a new bass boost control, cache storage split into multiple files, and several new commands/settings. It also includes fixes for YouTube search compatibility and improved status metadata handling, and chained commands.

Key Features
- Queue playback mode (m q) that plays items in FIFO order, integrated into player logic (next/end-file behavior).
- Queue management command (q) for listing, adding current track, removing by index, and clearing.
- Play/search behavior updated to enqueue in queue mode (p/u) without interrupting current playback.
- Optional position saving (ep) for seekable tracks; recents resume from saved position on r N.
- Bass boost command (bb) with 0–100 level scale, saved to config and applied at startup.
- User channel move command (go) allowing users to bring the bot into their channel (guarded by back_to_root_channel).
- Mute toggle command (mu) using mpv mute property.
- Time command (t) for elapsed/total playback duration and remaining time via tr.

Commands Added/Changed
User commands:
- t: show elapsed/total time for current playback.
- tr: show remaining time for current playback.
- ep: toggle position saving (enable_positions in config).
- bb [LEVEL]: set bass boost 0–100, bb shows current level.
- mu: toggle mute.
- q: queue management (q list, q + add current, q -N remove, q c clear).
- p: when in queue mode, search first result and enqueue; starts playback if idle.
- u: when in queue mode, enqueue URL/stream/file; starts playback if idle.
- m: adds queue mode (q) alongside st/rt/tl/rtl/rnd.
- go: move bot to user’s channel (respects back_to_root_channel setting).

Admin commands:
- sm: toggle metadata display in status messages.
- br: toggle allowing users to move bot to their channels.
- q removed for quit; admin quit now qq/quit.
- cc: now supports q (queue) and p (saved positions).

Playback/Player Changes
- Mode.Queue added to player enums and queue-specific logic in next/previous/end-file.
- Queue playback consumes items and continues automatically until empty.
- Position saving on pause/stop and before switching tracks if enabled.
- Resume positions stored on Track objects and applied on recents playback via delayed seek.
- Bass boost now uses mpv audio filter property (af) with a 0–100 scale mapped to gain -30..30.

Config and Migrations
- config version bumped to v3.
- General config additions:
  - back_to_root_channel
  - showmeta
  - enable_positions (default false)
- Player config addition:
  - bass_boost_level
- Config migrator adds missing fields for existing configs.

Cache Storage Changes
- Cache format version bumped to v4.
- Cache split into multiple files under a cache directory:
  - recents.dat
  - favorites.dat
  - queue.dat
  - meta.json
- Legacy single-file cache is still readable; split is written on save.
- Cache locking removed in favor of simpler IO and separate files.

Status/Metadata
- Status text now respects showmeta setting:
  - When enabled, shows track name/URL.
  - When disabled, uses generic “Active audio playback” / “Paused audio playback.”
- Auto return to root channel when alone and back_to_root_channel is enabled.

Service Updates
- YouTube service patches:
  - Ignore deprecated httpx “proxies” kwarg on httpx>=0.28.
  - Avoid TypeError when channel id is None in youtubesearchpython.
- Search now guards against errors when building Track objects.

Tools
- TeamTalk SDK downloader improved to select a stable 5.15 version when available, with better logging and fallback to latest version.

Files Added
- bot/services/patches.py (YouTube compatibility patches)

Notes/Behavioral Changes
- Queue mode auto-starts at startup if configured and queue has items.
- Admin quit command is now qq/quit to free q for queue management.

Chained Commands
It is now possible to chain multiple commands using the | separator in a single message.
Example: "t | v 30" shows the playback time and sets the volume to 30.
The processing splits the message by |, executes each command sequentially, and sends the responses.

Testing
- No automated tests added. Manual validation recommended for:
  - Queue playback flow (p/u in queue mode, q management, m q).
  - Position saving and resuming with r N.
  - Bass boost level set/clear behavior.
  - Status text with showmeta on/off.
